### PR TITLE
Fix broken links

### DIFF
--- a/src/content/docs/axeos/install-onto-bitaxe.md
+++ b/src/content/docs/axeos/install-onto-bitaxe.md
@@ -51,7 +51,7 @@ boardversion,data,string,0.11
 Save the file, we need it in the next step.
 
 ## 4. Flash
-Download the latest firmware from the [release page](https://github.com/skot/ESP-Miner/releases) or [compile it yourself](compile). It should look like `esp-miner-factory-vX.X.X.bin`. Now you can finally flash your BitAxe! To do so type into a system terminal:
+Download the latest firmware from the [release page](https://github.com/skot/ESP-Miner/releases) or [compile it yourself](/axeos/compile). It should look like `esp-miner-factory-vX.X.X.bin`. Now you can finally flash your BitAxe! To do so type into a system terminal:
 ```bash /{[^{}]*\}/
 bitaxetool --config {path-to-config} --firmware {path-to-firmware}
 ```

--- a/src/content/docs/bitaxe/100.md
+++ b/src/content/docs/bitaxe/100.md
@@ -2,7 +2,7 @@
 title: "Bitaxe 100 'Max'"
 logo: ./bitaxe-logo.svg
 discordChannel: https://discord.com/channels/1091348375301013615/1094385604982210633
-githubRepo: https://github.com/skot/bitaxe/tree/max-v2.3
+githubRepo: https://github.com/bitaxeorg/bitaxeMax
 ---
 
 The BitaxeMax is the world's first open source Bitcoin Miner which uses the ASIC BM1397 chip to achieve astonishing results.
@@ -38,7 +38,7 @@ The BitaxeMAX can be either purchased as a fully functional standalone Bitcoin m
 
    - These two readme files will guide you through the process of whats needed to build and order your own BitaxeMAX board.
      - [Assembly-readme](/tips/assembly)
-     - [Building-readme](/tips/building)
+     - [Building-readme](/tips/building-pcbs)
    - There are some Videos and Streams about how to Assembly a Bitaxe from scratch from some YouTubers such as [D-Central](https://www.youtube.com/@DCentralTech) and [WantClue](https://www.youtube.com/@WantClue)
 
 2. Schematics
@@ -46,7 +46,7 @@ The BitaxeMAX can be either purchased as a fully functional standalone Bitcoin m
    - Furthermore, for a more detailed view of the schematics of the BitaxeMAX board, you can view [BitaxeMaxSchematic](/doc-assets/bitaxe/bitaxeMax_schematic.pdf).
 
 3. Manufacturing Files
-   - In the [Manufacturing_Files_Folder](Manufacturing_Files) you will find all the necessary files to create your own PCB from Gerber files and the BOM(Build of Matierial) a list of all the components needed to build the BitaxeMAX
+   - In the [Manufacturing_Files_Folder](https://github.com/bitaxeorg/bitaxeMax/tree/max-v2.2/Manufacturing%20Files) you will find all the necessary files to create your own PCB from Gerber files and the BOM(Build of Matierial) a list of all the components needed to build the BitaxeMAX
 
 ![bitaxeMAX](./render-bitaxe-max.png)
 

--- a/src/content/docs/bitaxe/200.md
+++ b/src/content/docs/bitaxe/200.md
@@ -2,7 +2,7 @@
 title: "Bitaxe 200 'Ultra'"
 logo: ./bitaxe-logo.svg
 discordChannel: https://discord.com/channels/1091348375301013615/1131234857733857332
-githubRepo: https://github.com/skot/bitaxe/tree/max-v2.3
+githubRepo: https://github.com/bitaxeorg/bitaxeUltra
 ---
 
 The Bitaxe Ultra is the currently most used model.
@@ -69,15 +69,15 @@ The BM1366 appears to roll more than just the nonce on the chip. This is great n
 
 ## ⚙️ Guide
 
-The BitaxeUltra can be either purchased as a fully functional standalone Bitcoin miner, or you can build your own with the following guides in [Assembly](/tips/assembly) and [Building](/tips/building). Building this on your own will take much longer and requires a high skillset of SMD soldering and handling.
+The BitaxeUltra can be either purchased as a fully functional standalone Bitcoin miner, or you can build your own with the following guides in [Assembly](/tips/assembly) and [Building](/tips/building-pcbs). Building this on your own will take much longer and requires a high skillset of SMD soldering and handling.
 
 ## Building
 
 1. Building and Assembliy
 
    - These two readme files will guide you throu the process of whats needed to build and order your own BitaxeUltra board.
-     - [Assembly-readme](/tips/assembly)
-     - [Building-readme](/tips/building)
+     - [Assembly Guide](/tips/assembly)
+     - [Building Guide](/tips/building-pcbs)
    - There are some Videos and Streams about how to Assembly a Bitaxe from scratch from some YouTubers such as [D-Central](https://www.youtube.com/@DCentralTech) and [WantClue](https://www.youtube.com/@WantClue)
 
 2. Schematics
@@ -85,7 +85,7 @@ The BitaxeUltra can be either purchased as a fully functional standalone Bitcoin
    - Futhermore for a more detailed view into the Schematics of the BitaxeUltra board you can view [BitaxeUltraSchematic](/doc-assets/bitaxe/BitaxeUltra-schematic.pdf).
 
 3. Manufacturing Files
-   - In the [Manufacturing_Files_Folder](Manufacturing_Files) you will find all the necessary files to create your own PCB from Gerber files and the BOM(Build of Matierial) a list of all the components needed to build the BitaxeUltra
+   - In the [Manufacturing_Files_Folder](https://github.com/bitaxeorg/bitaxeUltra/tree/ultra-205/Manufacturing%20Files) you will find all the necessary files to create your own PCB from Gerber files and the BOM(Build of Matierial) a list of all the components needed to build the BitaxeUltra
 
 ---
 

--- a/src/content/docs/bitaxe/400.md
+++ b/src/content/docs/bitaxe/400.md
@@ -2,7 +2,7 @@
 title: "Bitaxe 400 'Supra'"
 logo: ./bitaxe-logo.svg
 discordChannel: https://discord.com/channels/1091348375301013615/1131234857733857332
-githubRepo: https://github.com/skot/bitaxe
+githubRepo: https://github.com/bitaxeorg/bitaxeSupra
 ---
 
 ![bitaxe-supra](./supra_render.png)

--- a/src/content/docs/bitaxe/about.md
+++ b/src/content/docs/bitaxe/about.md
@@ -22,7 +22,7 @@ shops:
     link: https://www.thesolomining.co/bitaxe
     region: GB
   - name: Altair
-    link: https://altairtech.io/product-category/miners/bitaxe/
+    link: https://altairtech.io/product-category/miners/osm/
     region: US
   - name: Bitcoin Merch
     link: https://bitcoinmerch.com/de/pages/search-results-page?q=Bitaxe

--- a/src/content/docs/bitaxe/bithalo.md
+++ b/src/content/docs/bitaxe/bithalo.md
@@ -9,7 +9,7 @@ githubRepo: https://github.com/IamGPIO
 
 # The first ever released Addon for Bitaxe!
 
-The BitHalo is a newly designed and manufactured product by [TheSoloMiningCo](https://www.thesolomining.co/product-page/bithalo-plug-and-play). It is a bespoke light board with side emitting LED's that react to processes during the mining operation.
+The BitHalo is a newly designed and manufactured product by [TheSoloMiningCo](https://github.com/IamGPIO/BitHalo-201-204-Bitaxe). It is a bespoke light board with side emitting LED's that react to processes during the mining operation.
 
 Upon loading, you are presented with a rotating purple lighting effect. Once all system are initalised, the orange pulse feature is loaded.
 

--- a/src/content/docs/piaxe/about.md
+++ b/src/content/docs/piaxe/about.md
@@ -26,7 +26,7 @@ The PiAxe's underlying hardware is the Raspberry Pi and it can be viewed as an e
 
 ## ⚙️ Guide
 
-Currently there only exists 1 Build of the PiAxe. If you wish to build your own take a look at the [Build Guide](building) and [Assembly Guide](assembly)
+Currently there only exists 1 Build of the PiAxe. If you wish to build your own take a look at the [Building Guide](/tips/building-pcbs) and [Assembly Guide](/tips/assembly)
 
 ### Software
 


### PR DESCRIPTION
I checked the website for broken links. The following list shows the results. This PR fixes the links. I also corrected some incorrect GitHub links in the page header.

* https://altairtech.io/product-category/miners/bitaxe/
    APPEARS ON: https://osmu.wiki/bitaxe/about
    REPLACED BY: https://altairtech.io/product-category/miners/osm/

* https://www.thesolomining.co/product-page/bithalo-plug-and-play
    APPEARS ON: https://osmu.wiki/bitaxe/bithalo
    REPLACED BY: https://github.com/IamGPIO/BitHalo-201-204-Bitaxe

* https://osmu.wiki/tips/building
    APPEARS ON: https://osmu.wiki/bitaxe/100
    REPLACED BY: https://osmu.wiki/tips/building-pcbs

* https://osmu.wiki/Manufacturing_Files
    APPEARS ON: https://osmu.wiki/bitaxe/100
    REPLACED BY: https://github.com/bitaxeorg/bitaxeMax/tree/max-v2.2/Manufacturing%20Files

* https://osmu.wiki/BitaxeUltra/Manufacturing_Files/ibom.html
    APPEARS ON: https://osmu.wiki/bitaxe/200
    REPLACED BY: https://github.com/bitaxeorg/bitaxeUltra/tree/ultra-205/Manufacturing%20Files

* https://osmu.wiki/compile
    APPEARS ON: https://osmu.wiki/axeos/install-onto-bitaxe
    REPLACED BY: https://osmu.wiki/axeos/compile/

* https://osmu.wiki/building
    APPEARS ON: https://osmu.wiki/piaxe/about
    REPLACED BY: https://osmu.wiki/tips/building-pcbs

* https://osmu.wiki/assembly
    APPEARS ON: https://osmu.wiki/piaxe/about
    REPLACED BY: https://osmu.wiki/tips/assembly